### PR TITLE
Split Nelnet and Edfinancial provider implementations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 STUDENT_AID_PROVIDER=nelnet
-STUDENT_AID_USERNAME=your_nelnet_username
-STUDENT_AID_PASSWORD=your_nelnet_password
+STUDENT_AID_USERNAME=your_username
+STUDENT_AID_PASSWORD=your_password
 STUDENT_AID_MFA_METHOD=sms
+# Edfinancial only; used when the browser is not recognized.
+STUDENT_AID_DOB=MMDDYYYY
+STUDENT_AID_SSN=123456789
+OSA_STORAGE_DIR=.osa

--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
 
 # Open StudentAid
 
-View your preferred student loan provider's loan summary through an easy-to-use API wrapper.
+Read loan balances and per-loan details from supported `.studentaid.gov`
+servicers through one Python API.
+
+## Supported providers
+
+| Provider | Authentication | Data source |
+|---|---|---|
+| `nelnet` | Username, password, and SMS, email, or authenticator MFA | Nelnet borrower API |
+| `edfinancial` | Username, password, MFA, and DOB/SSN when the device is not recognized | Edfinancial Account Summary |
+
+The public calls are identical for both providers. Set
+`STUDENT_AID_PROVIDER` or pass `provider=` to select an implementation.
 
 > [!WARNING]
-> Only available with a headed session via Chromium due to restrictions by studentaid.gov.
+> Login and data retrieval require a headed Chromium session because the
+> servicer sites reject ordinary HTTP and headless-browser access. Linux
+> servers can use Xvfb.
 
 ## Setup
 
-### macOS
+### macOS or Linux desktop
 
 ```bash
 python3 -m venv .venv
@@ -18,16 +31,7 @@ python -m pip install -r requirements.txt -e .
 python -m playwright install chromium
 ```
 
-### Linux desktop session
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -r requirements.txt -e .
-python -m playwright install chromium
-```
-
-### Ubuntu terminal server
+### Ubuntu server
 
 ```bash
 sudo apt update
@@ -47,29 +51,95 @@ python -m pip install -r requirements.txt -e .
 python -m playwright install chromium
 ```
 
-## Methods
+## Configuration
 
-### Login
+Copy the variable names from `.env.example` into a local `.env`. Choose one
+provider and enter that provider's credentials:
+
+```dotenv
+STUDENT_AID_PROVIDER=edfinancial
+STUDENT_AID_USERNAME=your_username
+STUDENT_AID_PASSWORD=your_password
+STUDENT_AID_MFA_METHOD=sms
+STUDENT_AID_DOB=MMDDYYYY
+STUDENT_AID_SSN=123456789
+```
+
+`STUDENT_AID_DOB` and `STUDENT_AID_SSN` are only used by Edfinancial when it
+does not recognize the browser. Nelnet requires the account username rather
+than an email address.
+
+Do not commit `.env`, `.osa/`, or `.studentaid/`. They contain credentials or
+authenticated session material. These paths are excluded by the included
+`.gitignore`.
+
+## Usage
+
+Complete the first login interactively so MFA and any identity challenge can
+be answered. The saved session is reused on later calls.
+
+```python
+import open_studentaid
+
+open_studentaid.login(provider="edfinancial")
+
+total, count, raw = open_studentaid.loan_summary(provider="edfinancial")
+loans = open_studentaid.loan_details(provider="edfinancial")
+snapshot = open_studentaid.loan_snapshot(provider="edfinancial")
+```
+
+The same calls work for Nelnet:
+
+```python
+from open_studentaid import StudentAid
+
+student_aid = StudentAid(provider="nelnet")
+student_aid.login()
+print(student_aid.loan_snapshot())
+```
+
+If `STUDENT_AID_PROVIDER` is set, `provider=` can be omitted.
+
+### Public methods
 
 | Method | Description |
 |---|---|
-| `login()` | Log in with Nelnet credentials and SMS, email, or authenticator MFA. |
-| `ensure_login()` | Reuse or refresh the saved login. |
+| `login()` | Complete the selected provider's browser login and save the session. |
+| `ensure_login()` | Reuse or refresh the saved authentication state. |
 | `save_session()` | Save the current browser session under `.osa/`. |
-
-### Non-mutating methods
-
-| Method | Description |
-|---|---|
-| `loan_snapshot()` | Return total balance, loan count, and each account summary. |
-| `loan_summary()` | Return the total balance, loan count, and raw response. |
+| `loan_snapshot()` | Return total balance, loan count, normalized loans, and raw data. |
+| `loan_summary()` | Return total balance, loan count, and raw provider data. |
 | `loan_details()` | Return normalized details for each loan. |
 | `get_amount()` | Return the total amount owed. |
-| `get_data()` | Return the raw borrower data. |
+| `get_data()` | Return raw provider data. |
 
-Methods are available as top-level functions or on `StudentAid`.
+Methods are available as top-level functions and on `StudentAid`.
 
-The methods are designed for providers using a `.studentaid.gov` domain, including Nelnet, Aidvantage, and others.
+## Provider layout
+
+Provider-specific login and borrower-data implementations live in:
+
+```text
+open_studentaid/
+  nelnet/
+    auth.py
+    api.py
+  edfinancial/
+    auth.py
+    api.py
+```
+
+The top-level modules provide shared session management and dispatch, so
+adding a provider does not require changing application calls.
+
+## CLI
+
+```bash
+studentaid --provider edfinancial login
+studentaid --provider edfinancial amount
+studentaid --provider edfinancial details
+studentaid --provider edfinancial summary
+```
 
 ## Tests
 
@@ -89,4 +159,6 @@ MIT (see `LICENSE`).
 
 ## Notice
 
-Open StudentAid is not affiliated with, endorsed by, or sponsored by StudentAid.gov, Nelnet, Aidvantage, or any other loan provider. Use it at your own risk and only to view your own data.
+Open StudentAid is not affiliated with, endorsed by, or sponsored by
+StudentAid.gov, Nelnet, Edfinancial, or the U.S. Department of Education. Use
+it at your own risk and only to access your own data.

--- a/open_studentaid/__init__.py
+++ b/open_studentaid/__init__.py
@@ -34,6 +34,8 @@ def login(
     background: bool = False,
     get_code: Optional[Callable[[str], str]] = None,
     mfa_code: Optional[str] = None,
+    date_of_birth: Optional[str] = None,
+    social_security_number: Optional[str] = None,
     debug: bool = False,
     timeout_seconds: int = 180,
 ) -> Dict[str, Any]:
@@ -57,6 +59,8 @@ def login(
         background=background,
         get_code=get_code,
         mfa_code=mfa_code,
+        date_of_birth=date_of_birth,
+        social_security_number=social_security_number,
         debug=debug,
         timeout_seconds=timeout_seconds,
     )
@@ -110,7 +114,7 @@ def get_data(
     provider: str = DEFAULT_PROVIDER,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> Dict[str, Any]:
-    """Return the raw borrower-details payload from Nelnet."""
+    """Return the selected provider's raw borrower data."""
     _, _, raw = _loan_summary(provider=provider, client_id=client_id)
     return raw
 
@@ -154,6 +158,8 @@ class StudentAid:
         background: bool = False,
         get_code: Optional[Callable[[str], str]] = None,
         mfa_code: Optional[str] = None,
+        date_of_birth: Optional[str] = None,
+        social_security_number: Optional[str] = None,
         debug: bool = False,
         timeout_seconds: int = 180,
     ) -> Dict[str, Any]:
@@ -171,6 +177,8 @@ class StudentAid:
             background=background,
             get_code=get_code,
             mfa_code=mfa_code,
+            date_of_birth=date_of_birth,
+            social_security_number=social_security_number,
             debug=debug,
             timeout_seconds=timeout_seconds,
         )

--- a/open_studentaid/api.py
+++ b/open_studentaid/api.py
@@ -1,124 +1,33 @@
-# api.py
+"""Provider-neutral borrower data API."""
+
 from __future__ import annotations
-from typing import Tuple, Dict, Any, List
-import os
+
 import re
-import requests
+from typing import Any, Dict, List, Tuple
 
-from .openstudentaid import (
-    DEFAULT_CLIENT_ID,
-    DEFAULT_PROVIDER,
-    ProviderConfig,
-    ensure_access_token,
-    refresh_tokens,
-)
-from .config import LAST_SESSION_STATES, load_tokens, managed_display, save_tokens, session_state_path
-
-# In-process cache of discovered API bases per provider
-_API_BASE_CACHE: Dict[str, str] = {}
+from .edfinancial.api import borrower_details as _edfinancial_borrower_details
+from .nelnet.api import borrower_details as _nelnet_borrower_details
+from .openstudentaid import DEFAULT_CLIENT_ID, DEFAULT_PROVIDER
 
 
-def _money(x: Any) -> float:
-    """Convert Nelnet's numeric/currency strings into a usable float."""
-    if x is None:
+def _money(value: Any) -> float:
+    """Convert numeric and currency strings into a float."""
+    if value is None:
         return 0.0
-    if isinstance(x, (int, float)):
-        return float(x)
+    if isinstance(value, (int, float)):
+        return float(value)
     try:
-        value = str(x).strip()
-        if not value:
+        text = str(value).strip()
+        if not text:
             return 0.0
-        negative = value.startswith("(") and value.endswith(")")
-        match = re.search(r"-?\d+(?:\.\d+)?", value.replace(",", ""))
+        negative = text.startswith("(") and text.endswith(")")
+        match = re.search(r"-?\d+(?:\.\d+)?", text.replace(",", ""))
         if not match:
             return 0.0
         result = float(match.group(0))
         return -abs(result) if negative else result
     except Exception:
         return 0.0
-
-
-def _api_candidates(cfg: ProviderConfig) -> list[str]:
-    """Return the current API host first, with old hosts as compatibility fallbacks."""
-    key = cfg.provider
-    if key in _API_BASE_CACHE:
-        return [_API_BASE_CACHE[key]] + [
-            base
-            for base in (
-                f"https://mmaapi.{cfg.provider}.studentaid.gov",
-                f"https://api.{cfg.provider}.studentaid.gov",
-                f"https://{cfg.provider}.studentaid.gov",
-            )
-            if base != _API_BASE_CACHE[key]
-        ]
-    return [
-        f"https://mmaapi.{cfg.provider}.studentaid.gov",
-        f"https://api.{cfg.provider}.studentaid.gov",
-        f"https://{cfg.provider}.studentaid.gov",
-    ]
-
-
-def _browser_api_get(cfg: ProviderConfig, url: str, access_token: str):
-    """Call the borrower API from Playwright's browser-backed request context.
-
-    Nelnet's Akamai edge rejects the same OAuth request from the Python
-    requests client, but accepts it from the authenticated browser context.
-    """
-    try:
-        from playwright.sync_api import sync_playwright
-    except Exception as exc:  # pragma: no cover - depends on the user's environment
-        raise RuntimeError(
-            "Playwright is required to read borrower data. Install the project requirements."
-        ) from exc
-
-    storage_state = LAST_SESSION_STATES.get(cfg.provider)
-    state_path = session_state_path(cfg.provider)
-    if storage_state is None and state_path.exists():
-        storage_state = str(state_path)
-
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json, text/plain, */*",
-        "Origin": f"https://{cfg.provider}.studentaid.gov",
-        "Referer": f"https://{cfg.provider}.studentaid.gov/",
-    }
-    configured_user_agent = os.getenv("STUDENT_AID_API_USER_AGENT")
-    context_options = {"viewport": {"width": 1440, "height": 1000}}
-    if storage_state is not None:
-        context_options["storage_state"] = storage_state
-    if configured_user_agent:
-        context_options["user_agent"] = configured_user_agent
-        headers["User-Agent"] = configured_user_agent
-
-    browser = None
-    context = None
-    with managed_display(enabled=True):
-        with sync_playwright() as pw:
-            channel = os.getenv("STUDENT_AID_CHROME_CHANNEL", "chrome").strip() or "chrome"
-            launch_args = [
-                "--window-position=-32000,-32000",
-                "--window-size=1440,1000",
-                "--start-minimized",
-            ]
-            try:
-                browser = pw.chromium.launch(channel=channel, headless=False, args=launch_args)
-            except Exception:
-                browser = pw.chromium.launch(headless=False, args=launch_args)
-            try:
-                context = browser.new_context(**context_options)
-                response = context.request.get(url, headers=headers, timeout=30_000)
-                body = response.json() if response.ok else response.text()
-                return response.status, body
-            finally:
-                if context is not None:
-                    context.close()
-                if browser is not None:
-                    browser.close()
-
-
-def _raise_api_error(status: int, url: str, body: Any) -> None:
-    detail = body if isinstance(body, str) else ""
-    raise requests.HTTPError(f"{status} Client Error for url: {url} {detail[:400]}")
 
 
 def _loan_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -133,7 +42,7 @@ def _loan_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _loan_total(loan: Dict[str, Any]) -> float:
-    """Prefer an explicit current total and otherwise sum the known components."""
+    """Prefer an explicit current total and otherwise sum known components."""
     for key in (
         "totalCurrentBalance",
         "currentTotalBalance",
@@ -159,46 +68,27 @@ def _borrower_details(
     provider: str = DEFAULT_PROVIDER,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> Dict[str, Any]:
-    """
-    Fetch borrower details JSON from the servicer API.
-    """
-    cfg = ProviderConfig(provider=provider, client_id=client_id)
-    access_token = ensure_access_token(provider=cfg.provider, client_id=cfg.client_id)
+    normalized_provider = provider.strip().lower()
+    if normalized_provider == "edfinancial":
+        return _edfinancial_borrower_details(normalized_provider, client_id)
+    if normalized_provider == "nelnet":
+        return _nelnet_borrower_details(normalized_provider, client_id)
+    raise ValueError(
+        f"Unsupported provider '{provider}'. Supported providers: nelnet, edfinancial."
+    )
 
-    last_status = None
-    last_url = None
-    last_body: Any = None
-    for api_base in _api_candidates(cfg):
-        url = api_base + cfg.borrower_details_path
-        try:
-            status, body = _browser_api_get(cfg, url, access_token)
-        except Exception:
-            continue
-        last_status, last_url, last_body = status, url, body
-        if status in (403, 404, 405):
-            continue
-        if status == 401:
-            cached = load_tokens(cfg.provider) or {}
-            refresh_token = cached.get("refresh_token")
-            if refresh_token:
-                refreshed = refresh_tokens(cfg, refresh_token)
-                save_tokens(cfg.provider, refreshed)
-                access_token = refreshed["access_token"]
-            else:
-                access_token = ensure_access_token(provider=cfg.provider, client_id=cfg.client_id)
-            status, body = _browser_api_get(cfg, url, access_token)
-            last_status, last_url, last_body = status, url, body
-        if status >= 400:
-            _raise_api_error(status, url, body)
-        data = body
-        if not isinstance(data, dict):
-            raise RuntimeError(f"Nelnet API returned a non-object response from {url}")
-        _API_BASE_CACHE[cfg.provider] = api_base
-        return data
 
-    if last_status is not None and last_url is not None:
-        _raise_api_error(last_status, last_url, last_body)
-    raise RuntimeError(f"Unable to reach the Nelnet borrower details API for provider '{cfg.provider}'.")
+def _summary_values(data: Dict[str, Any]) -> Tuple[float, int]:
+    loans = _loan_list(data)
+    explicit_total = data.get("totalCurrentBalance")
+    explicit_count = data.get("totalNumberOfLoans")
+    total = (
+        _money(explicit_total)
+        if explicit_total not in (None, "")
+        else sum(_loan_total(loan) for loan in loans)
+    )
+    count = int(explicit_count) if explicit_count not in (None, "") else len(loans)
+    return total, count
 
 
 def loan_summary(
@@ -206,18 +96,38 @@ def loan_summary(
     provider: str = DEFAULT_PROVIDER,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> Tuple[float, int, Dict[str, Any]]:
-    """
-    Fetch borrower summary and return (total_balance, loan_count, raw_json).
-    """
+    """Return ``(total_balance, loan_count, raw_data)`` for either provider."""
     data = _borrower_details(provider=provider, client_id=client_id)
-    loans = _loan_list(data)
-    loan_count = len(loans)
+    total, count = _summary_values(data)
+    return total, count, data
 
-    total_balance = 0.0
-    for ln in loans:
-        total_balance += _loan_total(ln)
 
-    return total_balance, loan_count, data
+def _normalized_loan_details(loans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    details: List[Dict[str, Any]] = []
+    for loan in loans:
+        details.append(
+            {
+                "loanId": (
+                    loan.get("loanId")
+                    or loan.get("loanAccountNumber")
+                    or loan.get("loanNumber")
+                ),
+                "loanType": loan.get("loanTypeDescription") or loan.get("loanType"),
+                "servicer": loan.get("servicerName") or loan.get("loanServicer"),
+                "status": loan.get("status"),
+                "interestRate": (
+                    _money(loan.get("interestRate"))
+                    if loan.get("interestRate") not in (None, "")
+                    else None
+                ),
+                "principal": _money(loan.get("currentPrincipalBalance")),
+                "interest": _money(loan.get("currentInterest")),
+                "capitalizedInterest": _money(loan.get("capitalizedInterest")),
+                "lateFees": _money(loan.get("outstandingLateFees")),
+                "totalBalance": _loan_total(loan),
+            }
+        )
+    return details
 
 
 def loan_details(
@@ -225,38 +135,9 @@ def loan_details(
     provider: str = DEFAULT_PROVIDER,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> List[Dict[str, Any]]:
-    """
-    Return a list of per-loan balances and identifiers.
-    """
+    """Return normalized per-loan balances and identifiers."""
     data = _borrower_details(provider=provider, client_id=client_id)
-    loans = _loan_list(data)
-
-    return _normalized_loan_details(loans)
-
-
-def _normalized_loan_details(loans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    details: List[Dict[str, Any]] = []
-    for ln in loans:
-        principal = _money(ln.get("currentPrincipalBalance"))
-        curr_int = _money(ln.get("currentInterest"))
-        cap_int = _money(ln.get("capitalizedInterest"))
-        late = _money(ln.get("outstandingLateFees"))
-        total = _loan_total(ln)
-
-        details.append(
-            {
-                "loanId": ln.get("loanId") or ln.get("loanAccountNumber") or ln.get("loanNumber"),
-                "loanType": ln.get("loanTypeDescription") or ln.get("loanType"),
-                "servicer": ln.get("servicerName") or ln.get("loanServicer"),
-                "principal": principal,
-                "interest": curr_int,
-                "capitalizedInterest": cap_int,
-                "lateFees": late,
-                "totalBalance": total,
-            }
-        )
-
-    return details
+    return _normalized_loan_details(_loan_list(data))
 
 
 def loan_snapshot(
@@ -264,12 +145,12 @@ def loan_snapshot(
     provider: str = DEFAULT_PROVIDER,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> Dict[str, Any]:
-    """Fetch borrower data once and return totals plus a per-account summary."""
+    """Fetch once and return totals, normalized loans, and raw provider data."""
     data = _borrower_details(provider=provider, client_id=client_id)
-    loans = _loan_list(data)
+    total, count = _summary_values(data)
     return {
-        "totalBalance": sum(_loan_total(loan) for loan in loans),
-        "loanCount": len(loans),
-        "loans": _normalized_loan_details(loans),
+        "totalBalance": total,
+        "loanCount": count,
+        "loans": _normalized_loan_details(_loan_list(data)),
         "raw": data,
     }

--- a/open_studentaid/edfinancial/__init__.py
+++ b/open_studentaid/edfinancial/__init__.py
@@ -1,0 +1,22 @@
+"""Edfinancial provider implementation."""
+
+from .api import borrower_details, parse_account_summary
+from .auth import (
+    account_summary_present,
+    fill_identity_verification,
+    identity_verification_present,
+    login_url,
+    normalize_date_of_birth,
+    normalize_social_security_number,
+)
+
+__all__ = [
+    "account_summary_present",
+    "borrower_details",
+    "fill_identity_verification",
+    "identity_verification_present",
+    "login_url",
+    "normalize_date_of_birth",
+    "normalize_social_security_number",
+    "parse_account_summary",
+]

--- a/open_studentaid/edfinancial/api.py
+++ b/open_studentaid/edfinancial/api.py
@@ -1,0 +1,130 @@
+"""Edfinancial authenticated account-summary implementation."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict
+
+from bs4 import BeautifulSoup
+
+from ..config import managed_display, session_state_path
+from ..exceptions import RefreshFailedError
+
+
+def _money(value: Any) -> float:
+    match = re.search(r"-?\d+(?:\.\d+)?", str(value).replace(",", ""))
+    return float(match.group(0)) if match else 0.0
+
+
+def parse_account_summary(html: str, text: str) -> Dict[str, Any]:
+    balance_match = re.search(
+        r"Total\s+Current\s+Balance:\s*\$([\d,]+(?:\.\d{2})?)", text, re.I
+    )
+    count_match = re.search(r"Total\s+Number\s+of\s+Loans:\s*(\d+)", text, re.I)
+    if not balance_match or not count_match:
+        raise RuntimeError(
+            "Edfinancial's account-summary balance fields could not be parsed."
+        )
+
+    soup = BeautifulSoup(html, "html.parser")
+    loans = []
+    for row in soup.select("#transactions-info-container > tr"):
+        loan_cell = row.select_one("td.loan[title]")
+        if loan_cell is None:
+            continue
+        title = loan_cell.get("title", "").strip()
+        detail = loan_cell.select_one(".loanDetails")
+        detail_text = detail.get_text(" ", strip=True) if detail else ""
+        balance = re.search(
+            r"Current\s+Balance\s+\$([\d,]+(?:\.\d{2})?)", detail_text, re.I
+        )
+        rate = re.search(r"Interest\s+Rate\s+([\d.]+)%", detail_text, re.I)
+        type_cell = row.select_one("td[title='Type']")
+        status_cell = row.select_one("td.status[title]")
+        link = loan_cell.select_one("a[href*='loanId=']")
+        loan_id_match = re.search(r"[?&]loanId=(\d+)", link.get("href", "") if link else "")
+        loans.append(
+            {
+                "loanId": loan_id_match.group(1) if loan_id_match else title.split(" ", 1)[0],
+                "loanTypeDescription": title,
+                "loanType": type_cell.get_text(" ", strip=True) if type_cell else None,
+                "servicerName": "Edfinancial",
+                "status": status_cell.get("title") if status_cell else None,
+                "interestRate": float(rate.group(1)) if rate else None,
+                "currentBalance": _money(balance.group(1)) if balance else 0.0,
+            }
+        )
+
+    expected_count = int(count_match.group(1))
+    if len(loans) != expected_count:
+        raise RuntimeError(
+            f"Edfinancial reported {expected_count} loans but {len(loans)} rows were parsed."
+        )
+    return {
+        "provider": "edfinancial",
+        "totalCurrentBalance": _money(balance_match.group(1)),
+        "totalNumberOfLoans": expected_count,
+        "loans": loans,
+    }
+
+
+def borrower_details(provider: str, client_id: str) -> Dict[str, Any]:
+    del provider, client_id
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError(
+            "Playwright is required to read Edfinancial borrower data."
+        ) from exc
+
+    state_path = session_state_path("edfinancial")
+    if not state_path.exists():
+        raise RefreshFailedError(
+            "No saved Edfinancial browser session was found. Re-login is required."
+        )
+
+    browser = None
+    context = None
+    with managed_display(enabled=True):
+        with sync_playwright() as pw:
+            channel = os.getenv("STUDENT_AID_CHROME_CHANNEL", "chrome").strip() or "chrome"
+            launch_options = {
+                "headless": False,
+                "args": [
+                    "--window-position=-32000,-32000",
+                    "--window-size=1440,1000",
+                    "--start-minimized",
+                ],
+            }
+            try:
+                browser = pw.chromium.launch(channel=channel, **launch_options)
+            except Exception:
+                browser = pw.chromium.launch(**launch_options)
+            try:
+                context = browser.new_context(
+                    storage_state=str(state_path),
+                    viewport={"width": 1440, "height": 1000},
+                )
+                page = context.new_page()
+                page.goto(
+                    "https://myaccount.edfinancial.studentaid.gov/AccountSummary",
+                    wait_until="domcontentloaded",
+                    timeout=60_000,
+                )
+                page.wait_for_timeout(2_000)
+                text = page.locator("body").inner_text(timeout=10_000)
+                if (
+                    "myaccount.edfinancial.studentaid.gov" not in page.url
+                    or "Total Current Balance" not in text
+                ):
+                    raise RefreshFailedError(
+                        "The saved Edfinancial browser session expired. "
+                        f"Re-login is required; current URL: {page.url}"
+                    )
+                return parse_account_summary(page.content(), text)
+            finally:
+                if context is not None:
+                    context.close()
+                if browser is not None:
+                    browser.close()

--- a/open_studentaid/edfinancial/auth.py
+++ b/open_studentaid/edfinancial/auth.py
@@ -1,0 +1,195 @@
+"""Edfinancial CALM/MyAccount login behavior."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from urllib.parse import urlsplit
+
+from ..exceptions import LoginFlowError
+
+
+def login_url() -> str:
+    return "https://myaccount.edfinancial.studentaid.gov/"
+
+
+def _page_text(page) -> str:
+    try:
+        return page.locator("body").inner_text(timeout=2_000)
+    except Exception:
+        return ""
+
+
+def _first_visible(page, selectors: list[str]):
+    for selector in selectors:
+        try:
+            locator = page.locator(selector)
+            for index in range(locator.count()):
+                candidate = locator.nth(index)
+                if candidate.is_visible():
+                    return candidate
+        except Exception:
+            continue
+    return None
+
+
+def normalize_date_of_birth(value: str) -> tuple[str, str, str]:
+    digits = re.sub(r"\D+", "", str(value))
+    if len(digits) != 8:
+        raise LoginFlowError("STUDENT_AID_DOB must contain 8 digits in MMDDYYYY format.")
+    month, day, year = digits[:2], digits[2:4], digits[4:]
+    try:
+        parsed = date(int(year), int(month), int(day))
+    except ValueError as exc:
+        raise LoginFlowError("STUDENT_AID_DOB is not a valid calendar date.") from exc
+    if parsed > date.today():
+        raise LoginFlowError("STUDENT_AID_DOB cannot be in the future.")
+    return month, day, year
+
+
+def normalize_social_security_number(value: str) -> tuple[str, str, str]:
+    digits = re.sub(r"\D+", "", str(value))
+    if len(digits) != 9:
+        raise LoginFlowError("STUDENT_AID_SSN must contain exactly 9 digits.")
+    return digits[:3], digits[3:5], digits[5:]
+
+
+def identity_verification_present(page) -> bool:
+    text = _page_text(page).lower()
+    return "date of birth" in text and (
+        "social security number" in text
+        or "account number" in text
+        or "more information to keep you secure" in text
+    )
+
+
+def account_summary_present(page) -> bool:
+    parsed = urlsplit(page.url)
+    if parsed.hostname != "myaccount.edfinancial.studentaid.gov":
+        return False
+    return (
+        "/accountsummary" in parsed.path.lower()
+        and "total current balance" in _page_text(page).lower()
+    )
+
+
+def _visible_unique_inputs(page, selectors: list[str]):
+    found = []
+    seen = set()
+    for selector in selectors:
+        try:
+            locator = page.locator(selector)
+            for index in range(locator.count()):
+                candidate = locator.nth(index)
+                if not candidate.is_visible():
+                    continue
+                element_id = candidate.get_attribute("id")
+                name = candidate.get_attribute("name")
+                key = element_id or (f"{name}:{index}" if name else f"{selector}:{index}")
+                if key not in seen:
+                    seen.add(key)
+                    found.append(candidate)
+        except Exception:
+            continue
+    return found
+
+
+def _date_of_birth_fields(page):
+    month = _first_visible(
+        page,
+        [
+            "input[name*='birthMonth' i]",
+            "input[id*='birthMonth' i]",
+            "input[name*='dobMonth' i]",
+            "input[id*='dobMonth' i]",
+            "input[placeholder='MM' i]",
+            "input[aria-label*='birth month' i]",
+        ],
+    )
+    day = _first_visible(
+        page,
+        [
+            "input[name*='birthDay' i]",
+            "input[id*='birthDay' i]",
+            "input[name*='dobDay' i]",
+            "input[id*='dobDay' i]",
+            "input[placeholder='DD' i]",
+            "input[aria-label*='birth day' i]",
+        ],
+    )
+    year = _first_visible(
+        page,
+        [
+            "input[name*='birthYear' i]",
+            "input[id*='birthYear' i]",
+            "input[name*='dobYear' i]",
+            "input[id*='dobYear' i]",
+            "input[placeholder='YYYY' i]",
+            "input[aria-label*='birth year' i]",
+        ],
+    )
+    return month, day, year
+
+
+def _social_security_fields(page):
+    fields = _visible_unique_inputs(
+        page,
+        [
+            "input[name*='ssn' i]",
+            "input[id*='ssn' i]",
+            "input[name*='socialSecurity' i]",
+            "input[id*='socialSecurity' i]",
+            "input[aria-label*='social security' i]",
+        ],
+    )
+    if fields:
+        return fields
+
+    candidates = _visible_unique_inputs(
+        page, ["input[type='password']", "input[inputmode='numeric']"]
+    )
+    masked = []
+    for candidate in candidates:
+        placeholder = candidate.get_attribute("placeholder") or ""
+        maximum = candidate.get_attribute("maxlength") or ""
+        compact_placeholder = placeholder.replace(" ", "").replace("-", "")
+        if set(compact_placeholder) <= {"*"} and (
+            compact_placeholder or maximum in {"2", "3", "4"}
+        ):
+            masked.append(candidate)
+    return masked
+
+
+def fill_identity_verification(
+    page, date_of_birth: str, social_security_number: str
+) -> None:
+    month, day, year = normalize_date_of_birth(date_of_birth)
+    ssn_first, ssn_middle, ssn_last = normalize_social_security_number(
+        social_security_number
+    )
+    month_field, day_field, year_field = _date_of_birth_fields(page)
+    if month_field is None or day_field is None or year_field is None:
+        raise LoginFlowError(
+            f"Edfinancial's date-of-birth fields changed; current URL: {page.url}"
+        )
+
+    ssn_fields = _social_security_fields(page)
+    if len(ssn_fields) not in {1, 3}:
+        raise LoginFlowError(
+            "Edfinancial requires SSN identity verification, but its SSN fields "
+            f"could not be identified; current URL: {page.url}"
+        )
+
+    try:
+        month_field.fill(month, timeout=5_000)
+        day_field.fill(day, timeout=5_000)
+        year_field.fill(year, timeout=5_000)
+        if len(ssn_fields) == 1:
+            ssn_fields[0].fill(ssn_first + ssn_middle + ssn_last, timeout=5_000)
+        else:
+            for field, part in zip(ssn_fields, (ssn_first, ssn_middle, ssn_last)):
+                field.fill(part, timeout=5_000)
+    except Exception as exc:
+        raise LoginFlowError(
+            "Edfinancial's identity-verification fields could not be filled."
+        ) from exc

--- a/open_studentaid/exceptions.py
+++ b/open_studentaid/exceptions.py
@@ -1,0 +1,13 @@
+"""Public exceptions shared by all student-loan providers."""
+
+
+class TokenMissingError(RuntimeError):
+    """Raised when a provider needs a saved authentication session."""
+
+
+class RefreshFailedError(RuntimeError):
+    """Raised when a saved provider session can no longer be reused."""
+
+
+class LoginFlowError(RuntimeError):
+    """Raised when an interactive provider login cannot complete."""

--- a/open_studentaid/nelnet/__init__.py
+++ b/open_studentaid/nelnet/__init__.py
@@ -1,0 +1,6 @@
+"""Nelnet provider implementation."""
+
+from .api import borrower_details
+from .auth import login_url, validate_username
+
+__all__ = ["borrower_details", "login_url", "validate_username"]

--- a/open_studentaid/nelnet/api.py
+++ b/open_studentaid/nelnet/api.py
@@ -1,0 +1,132 @@
+"""Nelnet OAuth borrower API implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import requests
+
+from ..config import (
+    LAST_SESSION_STATES,
+    load_tokens,
+    managed_display,
+    save_tokens,
+    session_state_path,
+)
+
+_API_BASE_CACHE: Dict[str, str] = {}
+
+
+def _api_candidates(provider: str) -> list[str]:
+    cached = _API_BASE_CACHE.get(provider)
+    candidates = [
+        f"https://mmaapi.{provider}.studentaid.gov",
+        f"https://api.{provider}.studentaid.gov",
+        f"https://{provider}.studentaid.gov",
+    ]
+    return ([cached] if cached else []) + [base for base in candidates if base != cached]
+
+
+def _browser_api_get(provider: str, url: str, access_token: str):
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError(
+            "Playwright is required to read Nelnet borrower data."
+        ) from exc
+
+    storage_state = LAST_SESSION_STATES.get(provider)
+    state_path = session_state_path(provider)
+    if storage_state is None and state_path.exists():
+        storage_state = str(state_path)
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json, text/plain, */*",
+        "Origin": f"https://{provider}.studentaid.gov",
+        "Referer": f"https://{provider}.studentaid.gov/",
+    }
+    configured_user_agent = os.getenv("STUDENT_AID_API_USER_AGENT")
+    context_options = {"viewport": {"width": 1440, "height": 1000}}
+    if storage_state is not None:
+        context_options["storage_state"] = storage_state
+    if configured_user_agent:
+        context_options["user_agent"] = configured_user_agent
+        headers["User-Agent"] = configured_user_agent
+
+    browser = None
+    context = None
+    with managed_display(enabled=True):
+        with sync_playwright() as pw:
+            channel = os.getenv("STUDENT_AID_CHROME_CHANNEL", "chrome").strip() or "chrome"
+            launch_args = [
+                "--window-position=-32000,-32000",
+                "--window-size=1440,1000",
+                "--start-minimized",
+            ]
+            try:
+                browser = pw.chromium.launch(
+                    channel=channel, headless=False, args=launch_args
+                )
+            except Exception:
+                browser = pw.chromium.launch(headless=False, args=launch_args)
+            try:
+                context = browser.new_context(**context_options)
+                response = context.request.get(url, headers=headers, timeout=30_000)
+                body = response.json() if response.ok else response.text()
+                return response.status, body
+            finally:
+                if context is not None:
+                    context.close()
+                if browser is not None:
+                    browser.close()
+
+
+def _raise_api_error(status: int, url: str, body: Any) -> None:
+    detail = body if isinstance(body, str) else ""
+    raise requests.HTTPError(f"{status} Client Error for url: {url} {detail[:400]}")
+
+
+def borrower_details(provider: str, client_id: str) -> Dict[str, Any]:
+    # Imported lazily to avoid a module cycle during public API initialization.
+    from ..openstudentaid import ProviderConfig, ensure_access_token, refresh_tokens
+
+    cfg = ProviderConfig(provider=provider, client_id=client_id)
+    access_token = ensure_access_token(provider=provider, client_id=client_id)
+    last_status = None
+    last_url = None
+    last_body: Any = None
+
+    for api_base in _api_candidates(provider):
+        url = api_base + cfg.borrower_details_path
+        try:
+            status, body = _browser_api_get(provider, url, access_token)
+        except Exception:
+            continue
+        last_status, last_url, last_body = status, url, body
+        if status in (403, 404, 405):
+            continue
+        if status == 401:
+            cached = load_tokens(provider) or {}
+            refresh_token = cached.get("refresh_token")
+            if refresh_token:
+                refreshed = refresh_tokens(cfg, refresh_token)
+                save_tokens(provider, refreshed)
+                access_token = refreshed["access_token"]
+            else:
+                access_token = ensure_access_token(
+                    provider=provider, client_id=client_id
+                )
+            status, body = _browser_api_get(provider, url, access_token)
+            last_status, last_url, last_body = status, url, body
+        if status >= 400:
+            _raise_api_error(status, url, body)
+        if not isinstance(body, dict):
+            raise RuntimeError(f"Nelnet API returned a non-object response from {url}")
+        _API_BASE_CACHE[provider] = api_base
+        return body
+
+    if last_status is not None and last_url is not None:
+        _raise_api_error(last_status, last_url, last_body)
+    raise RuntimeError("Unable to reach the Nelnet borrower details API.")

--- a/open_studentaid/nelnet/auth.py
+++ b/open_studentaid/nelnet/auth.py
@@ -1,0 +1,15 @@
+"""Nelnet-specific login behavior."""
+
+from ..exceptions import LoginFlowError
+
+
+def login_url(provider: str = "nelnet") -> str:
+    return f"https://{provider}.studentaid.gov/account/login"
+
+
+def validate_username(username: str) -> None:
+    if "@" in username:
+        raise LoginFlowError(
+            "Nelnet requires the account username, not an email address. "
+            "No login request was sent."
+        )

--- a/open_studentaid/openstudentaid.py
+++ b/open_studentaid/openstudentaid.py
@@ -21,6 +21,17 @@ from .config import (
     session_state_path,
     write_session_state,
 )
+from .edfinancial.auth import (
+    account_summary_present as _edfinancial_account_summary_present,
+    fill_identity_verification as _fill_identity_verification,
+    identity_verification_present as _identity_verification_present,
+    login_url as _edfinancial_login_url,
+    normalize_date_of_birth as _normalize_date_of_birth,
+    normalize_social_security_number as _normalize_social_security_number,
+)
+from .exceptions import LoginFlowError, RefreshFailedError, TokenMissingError
+from .nelnet.auth import login_url as _nelnet_login_url
+from .nelnet.auth import validate_username as _validate_nelnet_username
 
 
 load_dotenv()
@@ -49,18 +60,6 @@ class ProviderConfig:
     @property
     def borrower_details_path(self) -> str:
         return "/api/1/borrower/details"
-
-
-class TokenMissingError(RuntimeError):
-    """Raised when an API call needs a token but no saved token is available."""
-
-
-class RefreshFailedError(RuntimeError):
-    """Raised when the cached refresh token cannot be exchanged."""
-
-
-class LoginFlowError(RuntimeError):
-    """Raised when the interactive Playwright login cannot reach an authenticated state."""
 
 
 _DEFAULT_TIMEOUT_SECONDS = 180
@@ -256,6 +255,7 @@ def _accept_federal_notice(page, tracer: _FlowTracer) -> bool:
         page,
         [
             "#accept-disclaimer",
+            "#Accept",
             "button[aria-label*='accept federal usage disclaimer' i]",
         ],
     )
@@ -640,10 +640,12 @@ def login_playwright(
     background: bool = False,
     get_code: Optional[Callable[[str], str]] = None,
     mfa_code: Optional[str] = None,
+    date_of_birth: Optional[str] = None,
+    social_security_number: Optional[str] = None,
     debug: bool = False,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
-    """Log in through the real Nelnet browser flow and save the OAuth token payload.
+    """Log in through the selected servicer's browser flow and save the session.
 
     Always use a headed real Chrome session because the current Nelnet edge layer rejects
     automated browser modes. MFA can be supplied interactively, with ``get_code``, or
@@ -651,12 +653,9 @@ def login_playwright(
     """
     provider = provider.strip().lower()
     if not username.strip() or not password:
-        raise LoginFlowError("A Nelnet username and password are required.")
+        raise LoginFlowError("A StudentAid username and password are required.")
     if provider == "nelnet" and "@" in username:
-        raise LoginFlowError(
-            "Nelnet requires the account username, not an email address. "
-            "No login request was sent."
-        )
+        _validate_nelnet_username(username)
     if save_session is None:
         save_session = remember_device if remember_device is not None else True
     if trusted_device is None:
@@ -676,10 +675,26 @@ def login_playwright(
         raise LoginFlowError("mfa_method must be 'sms', 'email', or 'authenticator'")
 
     cfg = ProviderConfig(provider=provider, client_id=client_id)
+    resolved_date_of_birth = date_of_birth or _env_first(
+        "STUDENT_AID_DOB", "STUDENT_AID_DATE_OF_BIRTH", "DATE_OF_BIRTH", "DOB"
+    )
+    resolved_social_security_number = social_security_number or _env_first(
+        "STUDENT_AID_SSN", "SOCIAL_SECURITY_NUMBER", "SSN"
+    )
     sync_playwright = _require_playwright()
     tracer = _FlowTracer(
         enabled=debug,
-        secrets=[username, password, mfa_code or _env_first("STUDENT_AID_MFA_CODE", "MFA_CODE", "mfa_code") or ""],
+        secrets=[
+            username,
+            password,
+            mfa_code
+            or _env_first("STUDENT_AID_MFA_CODE", "MFA_CODE", "mfa_code")
+            or "",
+            resolved_date_of_birth or "",
+            re.sub(r"\D+", "", resolved_date_of_birth or ""),
+            resolved_social_security_number or "",
+            re.sub(r"\D+", "", resolved_social_security_number or ""),
+        ],
     )
     token_payload: Optional[Dict[str, Any]] = None
     context = None
@@ -721,7 +736,7 @@ def login_playwright(
                 context, browser = _browser_context(
                     pw,
                     storage_dir,
-                    storage_state_path,
+                    None if cfg.provider == "edfinancial" else storage_state_path,
                     background=background,
                     viewport={"width": 1440, "height": 1000},
                 )
@@ -743,8 +758,13 @@ def login_playwright(
                     page = context.new_page()
                 if debug:
                     print(f"[DEBUG] Opening {cfg.provider} login in headed Chrome")
+                login_url = (
+                    _edfinancial_login_url()
+                    if cfg.provider == "edfinancial"
+                    else _nelnet_login_url(cfg.provider)
+                )
                 page.goto(
-                    f"https://{cfg.provider}.studentaid.gov/account/login",
+                    login_url,
                     wait_until="domcontentloaded",
                     timeout=60_000,
                 )
@@ -763,10 +783,64 @@ def login_playwright(
                 deadline = time.monotonic() + max(30, timeout_seconds)
                 choice_submitted = False
                 code_submitted = False
+                identity_submitted_at = None
                 while time.monotonic() < deadline and token_payload is None:
                     page = _active_page(context, page)
                     previous_url = last_url
                     last_url = page.url
+
+                    if (
+                        cfg.provider == "edfinancial"
+                        and _edfinancial_account_summary_present(page)
+                    ):
+                        token_payload = {
+                            "access_token": "browser-session",
+                            "token_type": "Browser",
+                            "expires_in": 86_400,
+                        }
+                        tracer.capture(page, "authenticated_account_summary")
+                        break
+
+                    if _identity_verification_present(page):
+                        if identity_submitted_at is not None:
+                            if time.monotonic() - identity_submitted_at < 5:
+                                page.wait_for_timeout(300)
+                                continue
+                            error = _login_error(page)
+                            if error:
+                                tracer.capture(page, "login_error", note=error)
+                                raise LoginFlowError(error)
+                            raise LoginFlowError(
+                                "Edfinancial identity verification did not complete. "
+                                "Check STUDENT_AID_DOB and STUDENT_AID_SSN, then retry."
+                            )
+                        if not resolved_date_of_birth or not resolved_social_security_number:
+                            raise LoginFlowError(
+                                "Edfinancial does not recognize this device and requires "
+                                "STUDENT_AID_DOB plus STUDENT_AID_SSN in the environment."
+                            )
+                        tracer.capture(page, "identity_verification_ready")
+                        _fill_identity_verification(
+                            page,
+                            resolved_date_of_birth,
+                            resolved_social_security_number,
+                        )
+                        if not _click_button(
+                            page,
+                            [r"continue", r"verify", r"submit", r"next"],
+                            timeout_ms=10_000,
+                        ):
+                            raise LoginFlowError(
+                                "Edfinancial's identity-verification submit button changed; "
+                                f"current URL: {page.url}"
+                            )
+                        identity_submitted_at = time.monotonic()
+                        tracer.capture(
+                            page, "identity_verification_submitted", screenshot=False
+                        )
+                        page.wait_for_timeout(500)
+                        continue
+
                     error = _login_error(page)
                     if error:
                         tracer.capture(page, "login_error", note=error)
@@ -812,8 +886,13 @@ def login_playwright(
                     LAST_SESSION_STATES[cfg.provider] = state
                     if save_session and storage_state_path is not None:
                         write_session_state(storage_state_path, state)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    if debug:
+                        print(f"[DEBUG] Could not save browser state: {exc}")
+                    if cfg.provider == "edfinancial":
+                        raise LoginFlowError(
+                            f"Could not save the Edfinancial browser session: {exc}"
+                        ) from exc
     except LoginFlowError as exc:
         if tracer.directory and "Debug artifacts:" not in str(exc):
             raise LoginFlowError(f"{exc} Debug artifacts: {tracer.directory}") from exc
@@ -837,7 +916,8 @@ def login_playwright(
 
     if not token_payload:
         raise LoginFlowError("Login completed without an OAuth access token.")
-    save_tokens(cfg.provider, token_payload)
+    if cfg.provider != "edfinancial":
+        save_tokens(cfg.provider, token_payload)
     return token_payload
 
 
@@ -886,6 +966,12 @@ def refresh_tokens(cfg: ProviderConfig, refresh_token: str) -> Dict[str, Any]:
 def ensure_access_token(provider: str = DEFAULT_PROVIDER, client_id: str = DEFAULT_CLIENT_ID) -> str:
     """Return a valid cached token, refreshing it when possible."""
     cfg = ProviderConfig(provider=provider.strip().lower(), client_id=client_id)
+    if cfg.provider == "edfinancial":
+        if session_state_path(cfg.provider).exists():
+            return "browser-session"
+        raise TokenMissingError(
+            "No saved Edfinancial browser session was found. Run login() once."
+        )
     tokens = load_tokens(cfg.provider)
     if not tokens:
         raise TokenMissingError(
@@ -941,23 +1027,27 @@ def login_full(
     background: bool = False,
     get_code: Optional[Callable[[str], str]] = None,
     mfa_code: Optional[str] = None,
+    date_of_birth: Optional[str] = None,
+    social_security_number: Optional[str] = None,
     debug: bool = False,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     """Resolve explicit/env/terminal credentials and run the Playwright login."""
+    provider = provider.strip().lower()
+    provider_prefix = "EDFINANCIAL" if provider == "edfinancial" else "NELNET"
     resolved_username = _resolve_credential(
         username,
         "STUDENT_AID_USERNAME",
-        "Nelnet username: ",
+        f"{provider.title()} username: ",
         secret=False,
-        aliases=("NELNET_USERNAME", "USERNAME", "username"),
+        aliases=(f"{provider_prefix}_USERNAME", "USERNAME", "username"),
     )
     resolved_password = _resolve_credential(
         password,
         "STUDENT_AID_PASSWORD",
-        "Nelnet password: ",
+        f"{provider.title()} password: ",
         secret=True,
-        aliases=("NELNET_PASSWORD", "PASSWORD", "password"),
+        aliases=(f"{provider_prefix}_PASSWORD", "PASSWORD", "password"),
     )
     resolved_method = mfa_method or _env_first(
         "STUDENT_AID_MFA_METHOD", "MFA_METHOD", "mfa_method"
@@ -979,6 +1069,8 @@ def login_full(
         background=background,
         get_code=get_code,
         mfa_code=mfa_code,
+        date_of_birth=date_of_birth,
+        social_security_number=social_security_number,
         debug=debug,
         timeout_seconds=timeout_seconds,
     )
@@ -1002,11 +1094,15 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     from .api import loan_details, loan_snapshot
 
-    parser = argparse.ArgumentParser(prog="studentaid", description="Read your Nelnet student-loan data")
+    parser = argparse.ArgumentParser(
+        prog="studentaid", description="Read supported StudentAid servicer data"
+    )
     parser.add_argument("--provider", default=DEFAULT_PROVIDER)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    login_parser = subparsers.add_parser("login", help="Complete Nelnet login and MFA")
+    login_parser = subparsers.add_parser(
+        "login", help="Complete servicer login and identity verification"
+    )
     login_parser.add_argument("--username")
     login_parser.add_argument("--mfa-method", choices=["sms", "email", "authenticator"], default=None)
     login_parser.add_argument("--background", action="store_true")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open-studentaid"
-version = "0.1.0"
-description = "Open-source Python wrapper for StudentAid.gov servicer APIs"
+version = "0.2.0"
+description = "One Python API for Nelnet and Edfinancial student-loan data"
 authors = [{ name = "Bradley Florence", email = "bradleyseanf@users.noreply.github.com" }]
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
     "requests==2.34.2",
@@ -16,11 +16,10 @@ dependencies = [
     "beautifulsoup4==4.15.0",
     "playwright==1.61.0",
 ]
-keywords = ["studentaid", "loan", "api", "nelnet", "usde", "education", "oauth2"]
+keywords = ["studentaid", "loan", "api", "nelnet", "edfinancial", "education", "oauth2"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/edfinancial_summary.html
+++ b/tests/edfinancial_summary.html
@@ -1,0 +1,30 @@
+<div>
+  <span>Total Current Balance: $5,500.25</span>
+  <span>Total Number of Loans: 2</span>
+</div>
+<table>
+  <tbody id="transactions-info-container">
+    <tr>
+      <td class="loan" title="1-01 Direct Loan - Unsubsidized">
+        <a href="/LoanDetails?loanId=101">1-01 Direct Loan - Unsubsidized</a>
+        <div class="loanDetails">
+          Current Balance $1,000.25
+          Interest Rate 4.990%
+        </div>
+      </td>
+      <td title="Type">Direct</td>
+      <td class="status" title="In Grace">In Grace</td>
+    </tr>
+    <tr>
+      <td class="loan" title="1-02 Direct Loan - Subsidized">
+        <a href="/LoanDetails?loanId=102">1-02 Direct Loan - Subsidized</a>
+        <div class="loanDetails">
+          Current Balance $4,500.00
+          Interest Rate 5.500%
+        </div>
+      </td>
+      <td title="Type">Direct</td>
+      <td class="status" title="In Grace">In Grace</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/test_openstudentaid.py
+++ b/tests/test_openstudentaid.py
@@ -8,9 +8,19 @@ from pathlib import Path
 from unittest.mock import patch
 
 import open_studentaid
-from open_studentaid.api import _loan_list, _loan_total, _money
+from open_studentaid.api import (
+    _loan_list,
+    _loan_total,
+    _money,
+    loan_details,
+    loan_snapshot,
+    loan_summary,
+)
+from open_studentaid.edfinancial.api import parse_account_summary
 from open_studentaid.openstudentaid import (
     _method_pattern,
+    _normalize_date_of_birth,
+    _normalize_social_security_number,
     _redact,
     _resolve_mfa_code,
     save_session as save_core_session,
@@ -48,6 +58,67 @@ class OpenStudentAidTests(unittest.TestCase):
         )
         with patch.dict(os.environ, {"STUDENT_AID_MFA_CODE": "999999"}):
             self.assertEqual(_resolve_mfa_code(get_code=None, mfa_code="123456"), "123456")
+
+    def test_identity_value_normalization(self):
+        self.assertEqual(_normalize_date_of_birth("12/18/2003"), ("12", "18", "2003"))
+        self.assertEqual(
+            _normalize_social_security_number("123-45-6789"),
+            ("123", "45", "6789"),
+        )
+
+    def test_edfinancial_account_summary_parser(self):
+        html = Path(__file__).with_name("edfinancial_summary.html").read_text()
+        data = parse_account_summary(
+            html,
+            "Total Current Balance: $5,500.25\nTotal Number of Loans: 2",
+        )
+
+        self.assertEqual(data["totalCurrentBalance"], 5500.25)
+        self.assertEqual(data["totalNumberOfLoans"], 2)
+        self.assertEqual(data["loans"][0]["loanId"], "101")
+        self.assertEqual(data["loans"][0]["currentBalance"], 1000.25)
+        self.assertEqual(data["loans"][1]["interestRate"], 5.5)
+
+    def test_public_calls_dispatch_to_edfinancial(self):
+        raw = {
+            "provider": "edfinancial",
+            "totalCurrentBalance": 5500.25,
+            "totalNumberOfLoans": 2,
+            "loans": [
+                {
+                    "loanId": "101",
+                    "loanTypeDescription": "Direct Loan - Unsubsidized",
+                    "servicerName": "Edfinancial",
+                    "status": "In Grace",
+                    "interestRate": 4.99,
+                    "currentBalance": 5500.25,
+                }
+            ],
+        }
+        with patch(
+            "open_studentaid.api._edfinancial_borrower_details", return_value=raw
+        ):
+            total, count, returned = loan_summary(provider="edfinancial")
+            details = loan_details(provider="edfinancial")
+            snapshot = loan_snapshot(provider="edfinancial")
+
+        self.assertEqual((total, count), (5500.25, 2))
+        self.assertIs(returned, raw)
+        self.assertEqual(details[0]["servicer"], "Edfinancial")
+        self.assertEqual(details[0]["totalBalance"], 5500.25)
+        self.assertEqual(snapshot["loanCount"], 2)
+
+    def test_public_calls_dispatch_to_nelnet(self):
+        with patch("open_studentaid.api._nelnet_borrower_details", return_value=MODELS):
+            total, count, returned = loan_summary(provider="nelnet")
+
+        self.assertEqual(total, 3028.0)
+        self.assertEqual(count, 2)
+        self.assertIs(returned, MODELS)
+
+    def test_unknown_provider_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported provider"):
+            loan_summary(provider="unknown")
 
     def test_session_state_is_secure_and_public_summary_is_exposed(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed
- split Nelnet OAuth/API behavior into `open_studentaid/nelnet/`
- add Edfinancial CALM/MyAccount login, DOB+SSN identity verification, session reuse, and per-loan HTML parsing under `open_studentaid/edfinancial/`
- keep the public `login`, `loan_summary`, `loan_details`, and `loan_snapshot` calls provider-neutral
- reject unsupported provider names instead of routing them through Nelnet assumptions
- document provider selection, credentials, security, CLI usage, and first-login behavior
- bump package metadata to `0.2.0`

## Why
Nelnet and Edfinancial use materially different authentication and borrower-data flows. Keeping both implementations in the shared modules made provider behavior difficult to maintain and caused Edfinancial detail calls to bypass its browser-backed data source.

## Impact
Existing Nelnet callers keep the same public API. Edfinancial callers use the same methods with `provider="edfinancial"` or `STUDENT_AID_PROVIDER=edfinancial`, and now receive normalized per-loan balances, status, and interest rates.

## Validation
- `python -m unittest discover -s tests -v` (10 tests passed)
- `python -m compileall -q open_studentaid tests`
- `python -m build`
- `python -m twine check dist/open_studentaid-0.2.0*`
- live saved-account Edfinancial login and snapshot: 6 loans, total balance `$15,791.57`
- confirmed the built wheel contains both provider subpackages